### PR TITLE
Introduce volume correction

### DIFF
--- a/addon/globalPlugins/useSharedComputers.py
+++ b/addon/globalPlugins/useSharedComputers.py
@@ -2,21 +2,21 @@
 # useSharedComputers: Plugin to using shared computers
 # https://github.com/nvaccess/nvda/issues/4093
 # https://github.com/nvaccess/nvda/pull/7506/files
-# Copyright (C) 2018 Noelia Ruiz Martínez
+# Copyright (C) 2018 Noelia Ruiz Martínez, Robert Hänggi 
 # Released under GPL 2
 
 import globalPluginHandler
 import addonHandler
-import wx
-import gui
+import gui, wx, time, tones, winUser, config
 from gui import guiHelper
 from gui import nvdaControls
 from gui.settingsDialogs import SettingsDialog
-import config
-import winUser
 from keyboardHandler import KeyboardInputGesture
 from globalCommands import SCRCAT_CONFIG
-
+from comtypes import HRESULT,GUID,IUnknown, COMMETHOD, POINTER, CoCreateInstance, cast, c_float
+from ctypes.wintypes import BOOL, DWORD, UINT 
+from logHandler import log
+from api import processPendingEvents
 addonHandler.initTranslation()
 
 confspec = {
@@ -29,22 +29,44 @@ config.conf.spec["useSharedComputers"] = confspec
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def handleConfigProfileSwitch(self):
-		activation = config.conf["numLockManager"]["activation"]
+		activation = config.conf["useSharedComputers"]["activation"]
 		if activation < 2 and winUser.getKeyState(winUser.VK_NUMLOCK) != activation:
 			KeyboardInputGesture.fromName("numLock").send()
 
 	def changeVolumeLevel(self, volumeLevel):
-		from comtypes.client import CreateObject
-		wSObj = CreateObject("wScript.Shell")
-		# (174=volume down, 175=volume up, 173= mute)
-		wSObj.SendKeys('{'+chr(174) + ' ' + '100' + '}')
-		wSObj.SendKeys('{'+chr(175) + ' ' + str(volumeLevel) + '}')
+		speakers=getVolumeObject()
+		if speakers is not None:
+			# should actually work on first attempt
+			# but level 0 is a pain
+			# to do: level 0 and mute at the same time is for some reason not recognizable
+			for attempt in range(2):
+				processPendingEvents()
+				level=int(speakers.GetMasterVolumeLevelScalar()*100)
+				log.info("Level Speakers at Startup: {} Percent".format(level))
+				if level<volumeLevel:
+					speakers.SetMasterVolumeLevelScalar(volumeLevel/100.0,None)
+				muteState= speakers.GetMute()
+				log.info("Speakers at Startup: {}".format(("Unmuted","Muted")[muteState]))
+				if muteState:
+					speakers.SetMute(0, None)
+				time.sleep(0.05)
+				log.info("Speakers after correction: {} Percent, {}".format(
+					int(speakers.GetMasterVolumeLevelScalar()*100),
+					("Unmuted","Muted")[speakers.GetMute()]))
+		else:
+			# As a fall-back, change the volume "manually"
+			volDown=KeyboardInputGesture.fromName("VolumeDown")
+			volUp=KeyboardInputGesture.fromName("VolumeUp")
+			# one keystroke = 2 % here, is that universal?
+			repeats=volumeLevel//2
+			# We are only interested in the side effect, hence the dummy underscore variable
+			_ = {key.send() for key in iter((volDown,)*repeats + (volUp,)*repeats)}
+			time.sleep(float(volumeLevel)/62)
 
 	def __init__(self):
 		super(globalPluginHandler.GlobalPlugin, self).__init__()
 		volLevel = config.conf["useSharedComputers"]["volumeLevel"]
 		if config.conf["useSharedComputers"]["changeVolumeLevel"]:
-			# We use wx.CallAfter() so that NVDA can speak messages
 			wx.CallAfter(self.changeVolumeLevel, volLevel)
 		self.numLockState = winUser.getKeyState(winUser.VK_NUMLOCK)
 		self.handleConfigProfileSwitch()
@@ -112,3 +134,79 @@ class AddonSettingsDialog(SettingsDialog):
 		config.conf["useSharedComputers"]["activation"] = self.activateList.Selection
 		config.conf["useSharedComputers"]["changeVolumeLevel"] = self.changeVolumeLevelCheckBox.Value
 		config.conf["useSharedComputers"]["volumeLevel"] = self.volumeLevel.Value
+
+# Audio Stuff
+def getVolumeObject():
+	CLSID_MMDeviceEnumerator = GUID('{BCDE0395-E52F-467C-8E3D-C4579291692E}')
+	deviceEnumerator = CoCreateInstance(CLSID_MMDeviceEnumerator, IMMDeviceEnumerator, 1)
+	volObj = cast(
+		deviceEnumerator.GetDefaultAudioEndpoint(0, 1).Activate(IAudioEndpointVolume._iid_, 7, None),
+		POINTER(IAudioEndpointVolume))
+	return volObj
+
+# for a ffull-fletched Audio wrapper
+# visit https://github.com/AndreMiras/pycaw
+class IAudioEndpointVolume(IUnknown):
+	_iid_ = GUID('{5CDF2C82-841E-4546-9722-0CF74078229A}')
+	_methods_ = (
+		COMMETHOD([], HRESULT, 'NotImpl1'),
+		COMMETHOD([], HRESULT, 'NotImpl2'),
+		COMMETHOD([], HRESULT, 'GetChannelCount', (['out'], POINTER(UINT), 'pnChannelCount')),
+		COMMETHOD([], HRESULT, 'SetMasterVolumeLevel',
+			(['in'], c_float, 'fLevelDB'), (['in'], POINTER(GUID), 'pguidEventContext')),
+		COMMETHOD([], HRESULT, 'SetMasterVolumeLevelScalar',
+			(['in'], c_float, 'fLevel'), (['in'], POINTER(GUID), 'pguidEventContext')),
+		COMMETHOD([], HRESULT, 'GetMasterVolumeLevel', (['out'], POINTER(c_float), 'pfLevelDB')),
+		COMMETHOD([], HRESULT, 'GetMasterVolumeLevelScalar', (['out'], POINTER(c_float), 'pfLevelDB')),
+		COMMETHOD([], HRESULT, 'SetChannelVolumeLevel',
+			(['in'], UINT, 'nChannel'), (['in'], c_float, 'fLevelDB'), (['in'], POINTER(GUID), 'pguidEventContext')),
+		COMMETHOD([], HRESULT, 'SetChannelVolumeLevelScalar',
+			(['in'], DWORD, 'nChannel'), (['in'], c_float, 'fLevelDB'), (['in'], POINTER(GUID), 'pguidEventContext')),
+		COMMETHOD([], HRESULT, 'GetChannelVolumeLevel',
+			(['in'], UINT, 'nChannel'),
+			(['out'], POINTER(c_float), 'pfLevelDB')),
+		COMMETHOD([], HRESULT, 'GetChannelVolumeLevelScalar',
+			(['in'], DWORD, 'nChannel'),
+			(['out'], POINTER(c_float), 'pfLevelDB')),
+		COMMETHOD([], HRESULT, 'SetMute', (['in'], BOOL, 'bMute'), (['in'], POINTER(GUID), 'pguidEventContext')),
+		COMMETHOD([], HRESULT, 'GetMute', (['out'], POINTER(BOOL), 'pbMute')),
+		COMMETHOD([], HRESULT, 'GetVolumeStepInfo',
+			(['out'], POINTER(DWORD), 'pnStep'),
+			(['out'], POINTER(DWORD), 'pnStepCount')),
+		COMMETHOD([], HRESULT, 'VolumeStepUp', (['in'], POINTER(GUID), 'pguidEventContext')),
+		COMMETHOD([], HRESULT, 'VolumeStepDown', (['in'], POINTER(GUID), 'pguidEventContext')),
+		COMMETHOD([], HRESULT, 'QueryHardwareSupport', (['out'], POINTER(DWORD), 'pdwHardwareSupportMask')),
+		COMMETHOD([], HRESULT, 'GetVolumeRange',
+			(['out'], POINTER(c_float), 'pfMin'),
+			(['out'], POINTER(c_float), 'pfMax'),
+			(['out'], POINTER(c_float), 'pfIncr')))
+
+class IMMDevice(IUnknown):
+	_iid_ = GUID('{D666063F-1587-4E43-81F1-B948E807363F}')
+	_methods_ = (
+		COMMETHOD([], HRESULT, 'Activate',
+			(['in'], POINTER(GUID), 'iid'),
+			(['in'], DWORD, 'dwClsCtx'),
+			(['in'], POINTER(DWORD), 'pActivationParams'),
+			(['out'], POINTER(POINTER(IUnknown)), 'ppInterface')),)
+
+class IMMDeviceCollection(IUnknown):
+	_iid_ = GUID('{0BD7A1BE-7A1A-44DB-8397-CC5392387B5E}')
+	_methods_ = (
+		COMMETHOD([], HRESULT, 'GetCount',
+			(['out'], POINTER(UINT), 'pcDevices')),
+		COMMETHOD([], HRESULT, 'Item',
+			(['in'], UINT, 'nDevice'),
+			(['out'], POINTER(POINTER(IMMDevice)), 'ppDevice')))
+
+class IMMDeviceEnumerator(IUnknown):
+	_iid_ = GUID('{A95664D2-9614-4F35-A746-DE8DB63617E6}')
+	_methods_ = (
+		COMMETHOD([], HRESULT, 'EnumAudioEndpoints',
+			(['in'], DWORD, 'dataFlow'),
+			(['in'], DWORD, 'dwStateMask'),
+			(['out'], POINTER(POINTER(IMMDeviceCollection)), 'ppDevices')),
+		COMMETHOD([], HRESULT, 'GetDefaultAudioEndpoint',
+			(['in'], DWORD, 'dataFlow'),
+			(['in'], DWORD, 'role'),
+			(['out'], POINTER(POINTER(IMMDevice)), 'ppDevices')),)

--- a/addon/globalPlugins/useSharedComputers.py
+++ b/addon/globalPlugins/useSharedComputers.py
@@ -114,17 +114,13 @@ class AddonSettingsDialog(SettingsDialog):
 		activateLabel = _("&Activate NumLock:")
 		self.activateChoices = (_("off"), _("on"), _("not changed"))
 		self.activateList = sHelper.addLabeledControl(activateLabel, wx.Choice, choices=self.activateChoices)
-
 		self.activateList.Selection = config.conf["useSharedComputers"]["activation"]
-
 		# Translators: label of a dialog.
 		self.changeVolumeLevelCheckBox = sHelper.addItem(wx.CheckBox(self, label=_("&Change volume level")))
 		self.changeVolumeLevelCheckBox.Value = config.conf["useSharedComputers"]["changeVolumeLevel"]
-		self.changeVolumeLevelCheckBox.Enabled = (config.conf.profiles[-1].name is None)
 		# Translators: Label of a dialog.
 		self.volumeLevel = sHelper.addLabeledControl(_("Volume level:"), nvdaControls.SelectOnFocusSpinCtrl,
 			min=0, max=100, initial=config.conf["useSharedComputers"]["volumeLevel"])
-		self.volumeLevel.Enabled = (config.conf.profiles[-1].name is None)
 
 	def postInit(self):
 		self.activateList.SetFocus()
@@ -132,8 +128,9 @@ class AddonSettingsDialog(SettingsDialog):
 	def onOk(self,evt):
 		super(AddonSettingsDialog, self).onOk(evt)
 		config.conf["useSharedComputers"]["activation"] = self.activateList.Selection
-		config.conf["useSharedComputers"]["changeVolumeLevel"] = self.changeVolumeLevelCheckBox.Value
-		config.conf["useSharedComputers"]["volumeLevel"] = self.volumeLevel.Value
+		# write only to the normal configuration
+		config.conf.profiles[0]["useSharedComputers"]["changeVolumeLevel"] = self.changeVolumeLevelCheckBox.Value
+		config.conf.profiles[0]["useSharedComputers"]["volumeLevel"] = self.volumeLevel.Value
 
 # Audio Stuff
 def getVolumeObject():

--- a/buildVars.py
+++ b/buildVars.py
@@ -17,13 +17,16 @@ addon_info = {
 	"addon_summary" : _("Use Shared Computers"),
 	# Add-on description
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
-	"addon_description" : _("""Adds the possibility of choosing the state of the numLock key at start or when changing configuration profiles, and the volume level when NVDA is loaded, ensuring it's not muted."""),
+	"addon_description" : _("""Adds the possibility of choosing the state of the numLock key at start or when changing configuration profiles.
+	Additionally, the Windows  master volume can be set, either as a minimum or as an absolute percentage.
+	This ensures that the user hears the screen reader even if the volume has previously been muted or turned to a low level.
+	It will be applied  on normal restarts or on reloading addons, not on profile changes."""),
 	# version
-	"addon_version" : "1.0-dev",
+	"addon_version" : "1.1-dev",
 	# Author(s)
-	"addon_author" : u"Noelia Ruiz Martínez <nrm1977@gmail.com>",
+	"addon_author" : u"Noelia Ruiz Martínez <nrm1977@gmail.com>, Robert Hänggi <aarjay.robert@gmail.com>",
 	# URL for the add-on documentation support
-	"addon_url" : None,
+	"addon_url" : "https://github.com/Robert-J-H/numLockManager",
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 }


### PR DESCRIPTION
IAudioEndpointVolume is now used to read and set mute state and levels.
The sending of volume up/down is kept as fall-back procedure.
Should for some reason the correction not work,so is it frequently
amendable by reloading addons (Control+NVDA+F3).
The GUI does currently not reflect the enhanced possibilities.